### PR TITLE
Update luneos-halium-7.1 for new targets and repo addresses

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -223,7 +223,7 @@
   <project path="prebuilts/sdk" name="platform/prebuilts/sdk" groups="pdk" clone-depth="1" remote="aosp" />
   <project path="sdk" name="platform/sdk" groups="pdk-cw-fs" />
   <project path="system/bt" name="android_system_bt" groups="pdk" remote="los" />
-  <project path="system/core" name="Halium/android_system_core" groups="pdk" remote="hal" />
+  <project path="system/core" name="Halium/android_system_core" revision="socket-path" groups="pdk" remote="hal" />
   <project path="system/extras" name="android_system_extras" groups="pdk" remote="los" />
   <project path="system/gatekeeper" name="platform/system/gatekeeper" groups="pdk" remote="aosp" />
   <project path="system/keymaster" name="android_system_keymaster" groups="pdk" remote="los" />

--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,8 @@
   <remote name="los"
 	fetch="https://github.com/LineageOS"
 	revision="refs/heads/cm-14.1" />
-
+  <remote name="Github"
+        fetch="git://github.com/" />
   <!-- Uses ubports gerrit server since halium does not have one yet -->
   <remote name="hal"
 	fetch="https://github.com"
@@ -25,7 +26,7 @@
 
   <project path="abi/cpp" name="platform/abi/cpp" groups="pdk" remote="aosp" />
 
-  <project path="build" name="Halium/android_build" groups="pdk,tradefed" remote="hal" >
+  <project path="build" name="Herrie82/android_build" groups="pdk,tradefed" remote="Github" revision="halium-7.1">
     <copyfile src="core/root.mk" dest="Makefile" />
   </project>
   <project path="build/blueprint" name="platform/build/blueprint" groups="pdk,tradefed" remote="aosp" />
@@ -226,7 +227,7 @@
   <project path="prebuilts/sdk" name="platform/prebuilts/sdk" groups="pdk" clone-depth="1" remote="aosp" />
   <project path="sdk" name="platform/sdk" groups="pdk-cw-fs" />
   <project path="system/bt" name="android_system_bt" groups="pdk" remote="los" />
-  <project path="system/core" name="Halium/android_system_core" revision="socket-path" groups="pdk" remote="hal" />
+  <project path="system/core" name="Herrie82/android_system_core" revision="halium-7.1" groups="pdk" remote="Github" />
   <project path="system/extras" name="android_system_extras" groups="pdk" remote="los" />
   <project path="system/gatekeeper" name="platform/system/gatekeeper" groups="pdk" remote="aosp" />
   <project path="system/keymaster" name="android_system_keymaster" groups="pdk" remote="los" />

--- a/default.xml
+++ b/default.xml
@@ -42,7 +42,9 @@
   <project path="device/qcom/common" name="android_device_qcom_common" groups="qcom" remote="los" />
   <project path="vendor/qcom/opensource/cryptfs_hw" name="android_vendor_qcom_opensource_cryptfs_hw" groups="qcom" remote="los" />
   <project path="external/boringssl" name="android_external_boringssl" groups="pdk" remote="los" />
+  <project path="external/bson" name="android_external_bson" remote="los" />
   <project path="external/busybox" name="Halium/android_external_busybox" groups="pdk" remote="hal" />
+  <project path="external/connectivity" name="android_external_connectivity" remote="los" />
   <project path="external/ntfs-3g" name="android_external_ntfs-3g" remote="los" />
   <project path="external/gptfdisk" name="android_external_gptfdisk" groups="pdk" remote="los" />
   <project path="external/exfat" name="android_external_exfat" remote="los" />
@@ -71,6 +73,7 @@
   <project path="external/harfbuzz_ng" name="platform/external/harfbuzz_ng" groups="pdk-cw-fs" />
   <project path="external/icu" name="android_external_icu" groups="pdk" remote="los" />
   <project path="external/iptables" name="android_external_iptables" groups="pdk" remote="los" /> 
+  <project path="external/iproute2" name="android_external_iproute2" groups="pdk" remote="los" />  
   <project path="external/jemalloc" name="android_external_jemalloc" remote="los" groups="pdk,flo" />
   <project path="external/jhead" name="platform/external/jhead" groups="pdk" remote="aosp" /> -->
   <project path="external/jsmn" name="platform/external/jsmn" groups="pdk" />

--- a/luneos_targets.xml
+++ b/luneos_targets.xml
@@ -22,6 +22,8 @@
   <project path="vendor/oneplus" name="TheMuppets/proprietary_vendor_oneplus" remote="Github" revision="cm-14.1"/>
   <!-- TheMuppets vendor for Motorola -->
   <project path="vendor/motorola" name="TheMuppets/proprietary_vendor_motorola" remote="Github" revision="cm-14.1"/>
+  <!-- TheMuppets vendor for Huawei -->
+  <project path="vendor/huawei" name="win8linux/proprietary_vendor_huawei" remote="Github" revision="halium-7.1"/>
 
   <!-- Halium 7.1 Xiaomi Mido -->
   <project path="device/xiaomi/mido" name="herrie82/android_device_xiaomi_mido" remote="Github" revision="pgz-14.1"/>
@@ -34,6 +36,11 @@
   <!-- Halium 7.1 Motorola G4 -->
   <project path="device/motorola/athene" name="lineageos/android_device_motorola_athene" remote="Github" revision="cm-14.1"/>
   <project path="kernel/motorola/msm8952" name="lineageos/android_kernel_motorola_msm8952" remote="Github" revision="cm-14.1"/>
+
+  <!-- Halium 7.1 Nexus 6P (Huawei Angler) -->
+  <project path="device/huawei/angler" name="lineageos/android_device_huawei_angler" remote="Github" revision="cm-14.1"/>
+  <project path="kernel/huawei/angler" name="win8linux/android_kernel_huawei_angler" remote="Github" revision="halium-7.1"/>
+
   
   <!-- Seeing that OnePlus is a daughter company of Oppo, it seems it uses some of it's technical bits, so we include these there too -->
   <project path="device/oppo/common" name="lineageos/android_device_oppo_common" remote="Github" revision="cm-14.1"/>

--- a/luneos_targets.xml
+++ b/luneos_targets.xml
@@ -14,7 +14,7 @@
   <project path="system/core" name="webOS-ports/android_system_core" groups="pdk" revision="wop-12.1"/>
  -->
   <!-- luneos/luneos-hal: contain patches to apply before starting the build. -->
-  <project path="luneos/luneos-hal" name="android_luneos_hal" remote="webos-ports" revision="halium-7.1"/>
+  <project path="luneos/luneos-hal" name="android_luneos_hal" remote="webos-ports" revision="herrie/halium-7.1"/>
   
   <!-- TheMuppets vendor for Xiaomi -->
   <project path="vendor/xiaomi" name="TheMuppets/proprietary_vendor_xiaomi" remote="Github" revision="cm-14.1"/>

--- a/luneos_targets.xml
+++ b/luneos_targets.xml
@@ -24,7 +24,7 @@
   <project path="vendor/motorola" name="TheMuppets/proprietary_vendor_motorola" remote="Github" revision="cm-14.1"/>
 
   <!-- Halium 7.1 Xiaomi Mido -->
-  <project path="device/xiaomi/mido" name="piggz/android_device_xiaomi_mido" remote="Github" revision="pgz-14.1"/>
+  <project path="device/xiaomi/mido" name="herrie82/android_device_xiaomi_mido" remote="Github" revision="pgz-14.1"/>
   <project path="kernel/xiaomi/msm8953" name="piggz/android_kernel_xiaomi_msm8953" remote="Github" revision="pgz-14.1-eb8"/>
 
   <!-- Halium 7.1 OnePlus Onyx -->

--- a/luneos_targets.xml
+++ b/luneos_targets.xml
@@ -14,7 +14,7 @@
   <project path="system/core" name="webOS-ports/android_system_core" groups="pdk" revision="wop-12.1"/>
  -->
   <!-- luneos/luneos-hal: contain patches to apply before starting the build. -->
-  <project path="luneos/luneos-hal" name="android_luneos_hal" remote="webos-ports" revision="herrie/halium-7.1"/>
+  <project path="luneos/luneos-hal" name="android_luneos_hal" remote="webos-ports" revision="halium-7.1"/>
   
   <!-- TheMuppets vendor for Xiaomi -->
   <project path="vendor/xiaomi" name="TheMuppets/proprietary_vendor_xiaomi" remote="Github" revision="cm-14.1"/>


### PR DESCRIPTION
Some fixes are pending upstream, therefore temporarily switching to Herrie82 forks. 

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>